### PR TITLE
fix: ensure to remove GIT_COMMIT_* env vars to avoid config overlapping

### DIFF
--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -64,7 +64,15 @@ func (p *Plugin) Validate() error {
 
 // Execute provides the implementation of the plugin.
 func (p *Plugin) Execute() error {
-	for _, env := range []string{"GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL"} {
+	gitEnv := []string{
+		"GIT_AUTHOR_NAME",
+		"GIT_AUTHOR_EMAIL",
+		"GIT_AUTHOR_DATE",
+		"GIT_COMMITTER_NAME",
+		"GIT_COMMITTER_EMAIL",
+		"GIT_COMMITTER_DATE",
+	}
+	for _, env := range gitEnv {
 		if err := os.Unsetenv(env); err != nil {
 			return err
 		}


### PR DESCRIPTION
The `GIT_COMMIT_*` environment variables are forcibly removed, as they otherwise always take precedence over the plugin configuration.